### PR TITLE
ci: 🎡 RAILS_ENV=production を明示的に定義した

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -57,6 +57,8 @@ jobs:
     if: ${{ github.ref_name == 'main' }}
     name: Cloud Run に production デプロイする
     runs-on: ubuntu-latest
+    env:
+      RAILS_ENV: production
     steps:
       - name: ソースコードをチェックアウトする
         uses: actions/checkout@v3

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -2,7 +2,7 @@ Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.
-  config.cache_classes = false
+  config.cache_classes = true
 
   # Eager load code on boot. This eager loads most of Rails and
   # your application in memory, allowing both threaded web servers


### PR DESCRIPTION
- Revert "fix: 🐛 production での cache_classes を false に修正した (#154)"
- ci: 🎡 RAILS_ENV=production を明示的に定義した
