### PR TITLE
fix: 🐛 A "bigdecimal" gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,7 @@ GEM
     ast (2.4.2)
     base64 (0.1.2)
     benchmark (0.4.1)
-    bigdecimal (1.4.4)
+    bigdecimal (3.2.2)
     bindex (0.8.1)
     buftok (0.3.0)
     builder (3.3.0)
@@ -118,6 +118,7 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
+    ffi (1.17.2-arm64-darwin)
     ffi (1.17.2-x86_64-linux-gnu)
     ffi-compiler (1.3.2)
       ffi (>= 1.15.5)
@@ -189,12 +190,15 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.4)
+    nokogiri (1.18.9-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.18.9-x86_64-linux-gnu)
       racc (~> 1.4)
     parallel (1.23.0)
     parser (3.2.2.3)
       ast (~> 2.4.1)
       racc
+    pg (1.6.0-arm64-darwin)
     pg (1.6.0-x86_64-linux)
     pp (0.6.2)
       prettyprint
@@ -360,6 +364,7 @@ GEM
     zeitwerk (2.7.3)
 
 PLATFORMS
+  arm64-darwin-24
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
```sh
$ bundle update bigdecimal --conservative
```